### PR TITLE
add workflow action on challenge branch

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'challenge'
 
   pull_request:
 


### PR DESCRIPTION
Since we changed branches for the sake of the competition, we adapted our applied workflows to new branch.